### PR TITLE
fix: Correct English spelling of cancelled

### DIFF
--- a/base.ts
+++ b/base.ts
@@ -1178,7 +1178,7 @@ Do you want to forward only this event or the whole series?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Meeting request has been canceled.</source>
+        <source>Meeting request has been cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2493,7 +2493,7 @@ Do you want to forward only this event or the whole series?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Meeting request has been canceled.</source>
+        <source>Meeting request has been cancelled.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
Currently there is a mix of English and American spelling, since the
base has 'sourcelanguage="en_GB"' they've been updated to all use the
English version of the spelling.